### PR TITLE
Responsive Props

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 branches:
   except:
   - review
+  - review-revert
 
 language: node_js
 node_js:

--- a/src/styling/css/Sizes.js
+++ b/src/styling/css/Sizes.js
@@ -1,0 +1,28 @@
+class Sizes {
+  constructor(value) {
+    this.privateValue = value;
+  }
+
+  get value() {
+    return this.privateValue;
+  }
+
+  get minimum() {
+    if (this.privateValue._ != null) {
+      return this.privateValue._;
+    }
+    const firstKeyThatStartsAtMinimum = Object.keys(this.privateValue).find(
+      k => k.charAt(0) === '_'
+    );
+    return this.privateValue[firstKeyThatStartsAtMinimum];
+  }
+
+  size(key) {
+    if (key === '_') {
+      return this.minimum;
+    }
+    return this.privateValue[key];
+  }
+}
+
+export default Sizes;

--- a/src/styling/css/css.js
+++ b/src/styling/css/css.js
@@ -1,0 +1,144 @@
+import { isArray } from 'util';
+import Sizes from './Sizes';
+
+/**
+ * Use this in your files that are using responsive-props-enabled components
+ *
+ * eg. <SomeComponent height="50px" background={responsiveProps({
+ *  "_-200px": "blue",
+ *  "200px-_": "red"
+ * })} />
+ */
+export const responsiveProps = value => new Sizes(value);
+
+const getPropsForTransform = (size, props) => {
+  const sizedProps = {};
+  Object.keys(props).forEach(k => {
+    if (props[k] instanceof Sizes) {
+      const matchingMediaQuery = props[k].size(size);
+      if (matchingMediaQuery) {
+        sizedProps[k] = props[k].size(size);
+      } else if (props[k].size('_') != null) {
+        sizedProps[k] = props[k].minimum;
+      }
+    } else {
+      sizedProps[k] = props[k];
+    }
+  });
+  return sizedProps;
+};
+
+/**
+ * Exported only for tests
+ */
+export const processCssRule = (prop, key, calculateValue) => props => {
+  if (props == null || prop == null || !props[prop]) {
+    return '';
+  }
+
+  const sizes =
+    props[prop] instanceof Sizes ? props[prop].value : { _: props[prop] };
+
+  let result = '';
+  const appendResult = add => {
+    result = `${result}\n${add}`;
+  };
+
+  const getResult = k => {
+    const calculatedKey =
+      typeof key === 'function' ? key(getPropsForTransform(k, props)) : key;
+    const cssKey = calculatedKey || prop;
+
+    let value = null;
+    if (calculateValue != null) {
+      if (typeof calculateValue === 'string') {
+        value = calculateValue;
+      } else if (typeof calculateValue === 'function') {
+        value = calculateValue(getPropsForTransform(k, props));
+      }
+    }
+    return `${cssKey}: ${value != null ? value : sizes[k]};`;
+  };
+
+  Object.keys(sizes).forEach(k => {
+    if (k === '_') {
+      appendResult(getResult(k));
+      return;
+    }
+
+    const split = k.split('-');
+    const min = split[0] !== '_' ? split[0] : null;
+    const max = split[1] !== '_' ? split[1] : null;
+    let signature = '@media all and';
+    if (min) {
+      signature += ` (min-width: ${split[0]})`;
+    }
+    if (max) {
+      signature += `${min ? ' and' : ''} (max-width: ${split[1]})`;
+    }
+    appendResult(`${signature} { ${getResult(k)} }`);
+  });
+
+  return result.substring(1);
+};
+
+/**
+ * Use in styled-components template tags, eg. styled.div`
+ *  ${css('margin')}
+ * `
+ *
+ * It automatically handles regular values as well as responsive values passed in
+ * via `responsiveProps`.
+ *
+ * Given one argument, `css` will fetch the given prop name, use it as the css key, and
+ * make the value of the prop equal to the value of the key
+ *
+ * eg. `css('margin') -> margin: <value of props['margin']>
+ *
+ * Given two arguments, `css` will fetch the given prop name, use the second argument as
+ * the css key, and make the value of the prop equal to the value of the key
+ *
+ * eg. `css('gap', 'grid-gap')` -> grid-gap: <value of props['gap']>
+ *
+ * You can also pass in a function to base the key on other props
+ *
+ * eg. `css('gap', (props) => props['anotherValue'])` -> <value of props['anotherValue']: <value of props['gap']>
+ *
+ * Given three arguments, `css` will fetch the given prop name, use the second argument as
+ * the css key, and use the third value to calculate the value
+ *
+ * eg. `css('gap', 'grid-gap', (props) => props['anotherValue'])` -> grid-gap: <value of props['anotherValue']>
+ *
+ * Passing in a non-function will force that value to be used regardless of the prop value. This is useful
+ * for boolean props
+ *
+ * eg. `css('centered', 'text-align', 'center')
+ *
+ * You can also use multiple rules and only the first matched rule will be used.
+ *
+ * eg. `css(['centered', 'text-align', 'center'], ['textAlign', 'text-align'])`
+ */
+export const css = (...args) => {
+  if (isArray(args[0])) {
+    if (isArray(args[0][0])) {
+      throw new Error(
+        '`css()` takes in positional arguments, not an array of arguments: eg. `css([], [], [])`, not `css([[], [], []])`'
+      );
+    }
+
+    return props => {
+      for (let i = 0; i < args.length; i += 1) {
+        const result = processCssRule(
+          args[i][0],
+          args[i][1],
+          args[i][2]
+        )(props);
+        if (result !== '') {
+          return result;
+        }
+      }
+      return '';
+    };
+  }
+  return processCssRule(args[0], args[1], args[2]);
+};

--- a/src/styling/css/css.test.js
+++ b/src/styling/css/css.test.js
@@ -1,0 +1,274 @@
+import { css, processCssRule, responsiveProps } from './css';
+
+describe('#css', () => {
+  test('returns a function', () => {
+    expect(typeof css('height')).toBe('function');
+  });
+
+  describe('null values', () => {
+    test('null props', () => {
+      expect(css('height')(undefined)).toBe('');
+    });
+
+    test('null prop argument', () => {
+      expect(css(null)({})).toBe('');
+    });
+  });
+
+  describe('using one argument: eg. css("height")', () => {
+    const value = '100px';
+    [
+      {
+        property: 'height',
+        propPassedAsArgument: 'height',
+        result: `height: ${value};`,
+      },
+      {
+        property: 'height',
+        propPassedAsArgument: 'width',
+        result: '',
+      },
+    ].forEach(testCase => {
+      test(`property is present = ${testCase.property ===
+        testCase.propPassedAsArgument}`, () => {
+        expect(
+          css(testCase.property)({
+            [testCase.propPassedAsArgument]: value,
+          })
+        ).toBe(testCase.result);
+      });
+    });
+  });
+
+  describe('using two arguments: eg. css("height", "min-height")', () => {
+    const value = '100px';
+    [
+      {
+        property: 'height',
+        key: 'min-height',
+        propPassedAsArgument: 'height',
+        result: `min-height: ${value};`,
+      },
+      {
+        property: 'height',
+        key: 'min-height',
+        propPassedAsArgument: 'width',
+        result: '',
+      },
+    ].forEach(testCase => {
+      test(`property is present = ${testCase.property ===
+        testCase.propPassedAsArgument}`, () => {
+        expect(
+          css(
+            testCase.property,
+            testCase.key
+          )({
+            [testCase.propPassedAsArgument]: value,
+          })
+        ).toBe(testCase.result);
+      });
+    });
+  });
+
+  describe('using three arguments: eg. css("height", "min-height", () => {})', () => {
+    const value = 'center';
+    [
+      {
+        property: 'centered',
+        key: 'align-items',
+        thirdArg: () => 'center',
+        propPassedAsArgument: 'centered',
+        result: `align-items: ${value};`,
+      },
+      {
+        property: 'centered',
+        key: 'align-items',
+        thirdArg: 'center',
+        propPassedAsArgument: 'centered',
+        result: `align-items: ${value};`,
+      },
+      {
+        property: 'centered',
+        key: 'align-items',
+        thirdArg: () => 'center',
+        propPassedAsArgument: 'right',
+        result: '',
+      },
+      {
+        property: 'centered',
+        key: 'align-items',
+        thirdArg: 'center',
+        propPassedAsArgument: 'right',
+        result: '',
+      },
+    ].forEach(testCase => {
+      test(`property is present = ${testCase.property ===
+        testCase.propPassedAsArgument}, third arg type = ${typeof testCase.thirdArg}`, () => {
+        expect(
+          css(
+            testCase.property,
+            testCase.key,
+            testCase.thirdArg
+          )({
+            [testCase.propPassedAsArgument]: value,
+          })
+        ).toBe(testCase.result);
+      });
+    });
+  });
+
+  describe('using multiple rules: eg. css([[...], [...]])', () => {
+    test('no rule matches', () => {
+      expect(
+        css(
+          ['centered', 'align-items', 'center'],
+          ['horizontalAlignment', 'align-items']
+        )({})
+      ).toBe('');
+    });
+
+    test('first rule matches', () => {
+      expect(
+        css(
+          ['centered', 'align-items', 'center'],
+          ['horizontalAlignment', 'align-items']
+        )({
+          centered: true,
+        })
+      ).toBe('align-items: center;');
+    });
+
+    test('second rule matches', () => {
+      expect(
+        css(
+          ['centered', 'align-items', 'center'],
+          ['horizontalAlignment', 'align-items']
+        )({
+          horizontalAlignment: 'flex-start',
+        })
+      ).toBe('align-items: flex-start;');
+    });
+
+    test('all rules match props present, but first rule value is falsey', () => {
+      expect(
+        css(
+          ['centered', 'align-items', 'center'],
+          ['horizontalAlignment', 'align-items']
+        )({
+          centered: false,
+          horizontalAlignment: 'center',
+        })
+      ).toBe('align-items: center;');
+    });
+
+    test('incorrect usage: passing an array of rules', () => {
+      expect(() =>
+        css([
+          ['centered', 'align-items', 'center'],
+          ['horizontalAlignment', 'align-items'],
+        ])({
+          centered: false,
+          horizontalAlignment: 'center',
+        })
+      ).toThrowError(
+        new Error(
+          '`css()` takes in positional arguments, not an array of arguments: eg. `css([], [], [])`, not `css([[], [], []])`'
+        )
+      );
+    });
+  });
+
+  describe('using `responsiveProps`', () => {
+    test('rule matches', () => {
+      expect(
+        css(
+          ['centered', 'align-items', 'center'],
+          ['horizontalAlignment', 'align-items']
+        )({
+          horizontalAlignment: responsiveProps({
+            '_-50px': 'center',
+            '50px-_': 'left',
+          }),
+        })
+      ).toBe(
+        '@media all and (max-width: 50px) { align-items: center; }\n@media all and (min-width: 50px) { align-items: left; }'
+      );
+    });
+  });
+});
+
+describe('#processCssRule', () => {
+  describe('no media queries', () => {
+    test('one argument', () => {
+      expect(
+        processCssRule('gap')({
+          gap: 'left',
+        })
+      ).toBe('gap: left;');
+    });
+
+    test('two arguments: string', () => {
+      expect(
+        processCssRule(
+          'gap',
+          'grid-gap'
+        )({
+          gap: 'left',
+        })
+      ).toBe('grid-gap: left;');
+    });
+
+    test('two arguments: function', () => {
+      expect(
+        processCssRule(
+          'gap',
+          props => `grid-gap-${props.gap}`
+        )({
+          gap: 'left',
+        })
+      ).toBe('grid-gap-left: left;');
+    });
+  });
+
+  describe('with media queries', () => {
+    test('one argument', () => {
+      expect(
+        processCssRule('gap')({
+          gap: responsiveProps({ '_-50px': 'center', '50px-_': 'left' }),
+          margin: responsiveProps({ '_-50px': 'up', '50px-_': 'down' }),
+        })
+      ).toBe(
+        '@media all and (max-width: 50px) { gap: center; }\n@media all and (min-width: 50px) { gap: left; }'
+      );
+    });
+
+    test('two arguments', () => {
+      expect(
+        processCssRule(
+          'gap',
+          'grid-gap'
+        )({
+          gap: responsiveProps({ '_-50px': 'center', '50px-_': 'left' }),
+          margin: responsiveProps({ '_-50px': 'up', '50px-_': 'down' }),
+        })
+      ).toBe(
+        '@media all and (max-width: 50px) { grid-gap: center; }\n@media all and (min-width: 50px) { grid-gap: left; }'
+      );
+    });
+
+    test('three arguments', () => {
+      expect(
+        processCssRule(
+          'gap',
+          'grid-gap',
+          props => `${props.gap}-${props.margin}`
+        )({
+          gap: responsiveProps({ '_-50px': 'center', '50px-_': 'left' }),
+          margin: responsiveProps({ '_-50px': 'up', '50px-_': 'down' }),
+        })
+      ).toBe(
+        '@media all and (max-width: 50px) { grid-gap: center-up; }\n@media all and (min-width: 50px) { grid-gap: left-down; }'
+      );
+    });
+  });
+});


### PR DESCRIPTION
These changes summarize functionality for:
a) super clean css in styled-components
b) drop-in responsive props resulting in media queries

**Non-Responsive Example:**

`App.js`
```
<Header gap="50px" />
```

`Header.js`
```
const Header = styled.div`
    ${css('gap', 'grid-gap')} //auto gets the prop 'gap', returns null if not passed, and renames the prop to 'grid-gap' in final css
`
```

**Responsive Example:**

`App.js`
```
<Header gap={responsiveProps({
    "_-200px": "5px",
    "200px-500px": "10px",
    "500px-_": "15px",
})} />
```

`Header.js`
```
const Header = styled.div`
    ${css('gap', 'grid-gap')} //auto gets the prop 'gap', returns null if not passed, and renames the prop to 'grid-gap' in final css, and transforms the given props into media queries
`
```

Same code in both examples in `Header.js`!